### PR TITLE
Move custom API over to FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # nws-api
-Fetch weather forecasts and the hazarous weather outlook from the National Weather Service
+Fetch weather forecasts and the hazardous weather outlook from the National Weather Service
+
+## FastAPI
+This branch is **highly** unstable, as I am currently rewriting the old, custom API to use [FastAPI](https://fastapi.tiangolo.com/). This will make the API *far* easier to implement in other products, and it will also be OpenAPI compatible.
 
 ## National Weather Service API Python Library
 This is a Python library that makes use of the [API Web Service](https://www.weather.gov/documentation/services-web-api) from the National Weather Service. The current implementation is very limited, as it is based solely on my own use case.

--- a/config.py
+++ b/config.py
@@ -12,7 +12,7 @@ DEFAULTS = {
     "server": {
         "address": "0.0.0.0",  # IP address / hostname to bind to (all by default)
         "port": 8080,  # Port to accept connections on
-        "keys": []  # List of dictionaries containing tokens and their permissions
+        "users": []  # List of dictionaries containing tokens and their permissions
     },
     # Global forecast settings
     # Location can be left blank

--- a/config.py
+++ b/config.py
@@ -12,7 +12,7 @@ DEFAULTS = {
     "server": {
         "address": "0.0.0.0",  # IP address / hostname to bind to (all by default)
         "port": 8080,  # Port to accept connections on
-        "key": None  # API key, which must be sent via the Authorization HTTP header
+        "keys": []  # List of dictionaries containing tokens and their permissions
     },
     # Global forecast settings
     # Location can be left blank
@@ -26,6 +26,34 @@ DEFAULTS = {
     "lon": None,
     "office": None # Force the NWS Office to use for the Hazardous Weather Outlook
 }
+
+# Example key item (for an admin):
+{
+    "name": "Admin",
+    "admin": true,
+    "token": "apiTokenHere"
+}
+
+# Example key item (for a read-only user):
+{
+    "name": "Read-Only user",
+    "admin": false,
+    "readOnly": true
+    "token": "apiTokenHere"
+}
+
+# Example key item (for an alert only user):
+{
+    "name": "Alert-only user",
+    "admin": false,
+    "alertOnly": true,
+    "token": "apiTokenHere"
+}
+
+Admin users inherently have ALL permissions.
+Read-only users can request forecast information (due to the nature of sending data, it is odd to consider them 
+  "read-only" since they POST data)
+Alert only users can ONLY send a POST request to the alert endpoint and nothing else.
 """
 
 

--- a/config.py
+++ b/config.py
@@ -36,13 +36,14 @@ class Config(dict):
     config_path: str
     __config: dict
 
-    def __init__(self, config_path: str = DEFAULT_CONFIG_FILE, data: dict = None) -> None:
+    def __init__(self, config_path: str = DEFAULT_CONFIG_FILE, data: dict = None, log_level: int = logging.INFO) -> None:
         super().__init__()
 
         if data is None:
             data = {}
 
         self.config_path = config_path
+        self.log_level = log_level
         self.__config = data
 
         if not data:
@@ -164,7 +165,7 @@ def set_log_level(level: str) -> None:
         logging.getLogger().setLevel("INFO")
 
 
-def load(config_path: str = DEFAULT_CONFIG_FILE, data: dict = None) -> dict:
+def load(config_path: str = DEFAULT_CONFIG_FILE, data: dict = None) -> Config:
     """
     Load the configuration YAML from the specified config file. If no file was specified, then DEFAULT_CONFIG_FILE is
      used
@@ -193,5 +194,7 @@ def load(config_path: str = DEFAULT_CONFIG_FILE, data: dict = None) -> dict:
     if "LOG_LEVEL" in os.environ and not manual_logging:
         logging.debug(f"Setting log level to {os.environ['LOG_LEVEL']} from environment")
         set_log_level(os.environ['LOG_LEVEL'])
+
+    config.log_level = logging.getLogger().level
 
     return config

--- a/config.py
+++ b/config.py
@@ -27,14 +27,14 @@ DEFAULTS = {
     "office": None # Force the NWS Office to use for the Hazardous Weather Outlook
 }
 
-# Example key item (for an admin):
+# Example user item (for an admin):
 {
     "name": "Admin",
     "admin": true,
     "token": "apiTokenHere"
 }
 
-# Example key item (for a read-only user):
+# Example user item (for a read-only user):
 {
     "name": "Read-Only user",
     "admin": false,
@@ -42,7 +42,7 @@ DEFAULTS = {
     "token": "apiTokenHere"
 }
 
-# Example key item (for an alert only user):
+# Example user item (for an alert only user):
 {
     "name": "Alert-only user",
     "admin": false,
@@ -224,5 +224,4 @@ def load(config_path: str = DEFAULT_CONFIG_FILE, data: dict = None) -> Config:
         set_log_level(os.environ['LOG_LEVEL'])
 
     config.log_level = logging.getLogger().level
-
     return config

--- a/examples/example_forecast.yml
+++ b/examples/example_forecast.yml
@@ -1,0 +1,17 @@
+locations: []
+server:
+  address: 0.0.0.0
+  port: 8080
+  users:
+  # Full admin user. Can POST alerts, view forecast information, and access admin endpoints
+  - admin: true
+    name: Admin
+    token: random_secure_token_here
+  # Read-only user. Can ONLY view forecast information
+  - readOnly: true
+    name: Read Only User
+    token: different_random_secure_token
+  # Alert-only user. Can ONLY POST alerts
+  - alertOnly: true
+    name: Alert Only User
+    token: another_different_random_token

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Fetches weather data from the National Weather Service.")
     parser.add_argument("-L", "--logging-level", choices=["debug", "info", "warning", "error", "critical"],
-                        help="Set the logging level to the provided value. For the least output, use error or critical.")
+                        help="Set the logging level to the provided value. For the least output, use error or critical")
     parser.add_argument("-l", "--log-file", help="Write logs to the specified file instead of to the console.")
     parser.add_argument("-c", "--config-file", action="store", default=config.DEFAULT_CONFIG_FILE,
                         help="Use the specified configuration YAML file instead of the default one.")
@@ -56,5 +56,4 @@ if __name__ == "__main__":
     else:
         app = FastAPI()
         api = APIv1(app=app, config=cfg)
-        print(cfg.log_level)
         uvicorn.run(app, host=cfg['server']['address'], port=cfg['server']['port'], log_level=cfg.log_level)

--- a/main.py
+++ b/main.py
@@ -2,13 +2,17 @@ if __name__ == "__main__":
     import sys
     import argparse
     import config
+
+    from fastapi import FastAPI
+    import uvicorn
+
     from forecast import Forecast
-    from server import Server, RequestHandler
+    from server import APIv1
 
     parser = argparse.ArgumentParser(description="Fetches weather data from the National Weather Service.")
     parser.add_argument("-L", "--logging-level", choices=["debug", "info", "warning", "error", "critical"],
                         help="Set the logging level to the provided value. For the least output, use error or critical.")
-    parser.add_argument("-O", "--log-file", help="Write logs to the specified file instead of to the console.")
+    parser.add_argument("-l", "--log-file", help="Write logs to the specified file instead of to the console.")
     parser.add_argument("-c", "--config-file", action="store", default=config.DEFAULT_CONFIG_FILE,
                         help="Use the specified configuration YAML file instead of the default one.")
     parser.add_argument("--no-server", action="store_true", help="Prints the Hazardous Weather Outlook"
@@ -50,5 +54,7 @@ if __name__ == "__main__":
         with open("forecast.json", "wt") as f:
             json.dump(forecasts, f)
     else:
-        s = Server((cfg['server']['address'], cfg['server']['port']), RequestHandler, cfg)
-        s.serve_forever()
+        app = FastAPI()
+        api = APIv1(app=app, config=cfg)
+        print(cfg.log_level)
+        uvicorn.run(app, host=cfg['server']['address'], port=cfg['server']['port'], log_level=cfg.log_level)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests
 pyyaml
 beautifulsoup4
 fastapi[standard]
+uvicorn
+pydantic

--- a/server.py
+++ b/server.py
@@ -86,11 +86,14 @@ class DsamePayload(BaseModel):
     MESSAGE: str
 
 
+# Enum for creating tokens
+# Only readOnly or alertOnly are possible
 class TokenType(str, Enum):
     readOnly = "readOnly"
     alertOnly = "alertOnly"
 
 
+# Model for modifying tokens
 class Token(BaseModel):
     name: str | None = None
     alertOnly: bool | None = None

--- a/server.py
+++ b/server.py
@@ -3,6 +3,8 @@ import json
 import logging
 import time
 
+from fastapi import FastAPI
+
 import forecast
 from config import ConfigError, load
 

--- a/server.py
+++ b/server.py
@@ -672,13 +672,15 @@ class APIv1:
         # /hourly
         return get_weather(payload)['hourly']
 
-    def get_hazardous_weather_outlook(self, payload: Payload) -> dict:
+    def get_hazardous_weather_outlook(self, payload: Payload) -> list | None:
         # /hwo
         return get_weather(payload)['hwo']
 
-    def get_spotter_activation_statement(self, payload: Payload) -> list:
+    def get_spotter_activation_statement(self, payload: Payload) -> list | None:
         # /spotter
         hwo = get_weather(payload)['hwo']
+        if hwo is None:
+            return None
         spotter = []
         for item in hwo:
             spotter.append(item['spotter'])


### PR DESCRIPTION
The current custom API is a little clunky and difficult to manage. This request fixes that issue by making use of [FastAPI](https://fastapi.tiangolo.com/). This will also allow the API to be OpenAPI compliant.